### PR TITLE
Including 'ctypes' package to load the shared libraries 'libcast.so' …

### DIFF
--- a/desktop/src/python/README.md
+++ b/desktop/src/python/README.md
@@ -10,4 +10,4 @@ Examples:
 Executing under Linux:
 - Install Pillow (latest PIL library) and PySide6 using pip
 - Copy the python programs to the extracted libs folder (where pycast.so and libcast.so are placed)
-- Execute: LD_LIBRARY_PATH=$LD_LIBRARY_PATH:. python3 {clarius_python_example}.py
+- Execute: python3 {clarius_python_example}.py

--- a/desktop/src/python/pycaster.py
+++ b/desktop/src/python/pycaster.py
@@ -2,6 +2,10 @@
 
 import argparse
 import os.path
+import ctypes
+
+libcast = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL) # load the libcast.so shared library
+pyclariuscast = ctypes.cdll.LoadLibrary('./pyclariuscast.so') # load the pyclariuscast.so shared library
 
 import pyclariuscast
 from PIL import Image

--- a/desktop/src/python/pyimu.py
+++ b/desktop/src/python/pyimu.py
@@ -2,6 +2,10 @@
 
 import os.path
 import sys
+import ctypes
+
+libcast = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL) # load the libcast.so shared library
+pyclariuscast = ctypes.cdll.LoadLibrary('./pyclariuscast.so') # load the pyclariuscast.so shared library
 
 import pyclariuscast
 from PySide6 import QtCore, QtGui, QtWidgets

--- a/desktop/src/python/pysidecaster.py
+++ b/desktop/src/python/pysidecaster.py
@@ -2,6 +2,10 @@
 
 import os.path
 import sys
+import ctypes
+
+libcast = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL) # load the libcast.so shared library
+pyclariuscast = ctypes.cdll.LoadLibrary('./pyclariuscast.so') # load the pyclariuscast.so shared library
 
 import pyclariuscast
 from PySide6 import QtCore, QtGui, QtWidgets


### PR DESCRIPTION
…and 'pyclariuscast.so' without requiring the LD_LIBRARY_PATH preamble from the command line. Details below:

Updated README.md to reflect there is no need for the LD_LIBRARY_PATH preamble.

Updated pysidecaster.py, pyimu.py, and pycaster.py to import ctypes, then load the shared libraries (from the same directory), then import pyclariuscast.

Tested and working.