### PR TITLE
Updated to properly unload the shared ctypes shared libraries before …

### DIFF
--- a/desktop/src/python/pycaster.py
+++ b/desktop/src/python/pycaster.py
@@ -4,7 +4,7 @@ import argparse
 import os.path
 import ctypes
 
-libcast = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL) # load the libcast.so shared library
+libcast_handle = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL)._handle # load the libcast.so shared library
 pyclariuscast = ctypes.cdll.LoadLibrary('./pyclariuscast.so') # load the pyclariuscast.so shared library
 
 import pyclariuscast
@@ -129,6 +129,8 @@ def main():
             print("connected to {0} on port {1}".format(args.ip, args.port))
         else:
             print("connection failed")
+            # unload the shared library before destroying the cast object
+            ctypes.CDLL('libc.so.6').dlclose(libcast_handle)
             cast.destroy()
             return
     else:

--- a/desktop/src/python/pyimu.py
+++ b/desktop/src/python/pyimu.py
@@ -4,7 +4,7 @@ import os.path
 import sys
 import ctypes
 
-libcast = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL) # load the libcast.so shared library
+libcast_handle = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL)._handle # load the libcast.so shared library
 pyclariuscast = ctypes.cdll.LoadLibrary('./pyclariuscast.so') # load the pyclariuscast.so shared library
 
 import pyclariuscast
@@ -193,6 +193,8 @@ class MainWidget(QtWidgets.QMainWindow):
     # handles shutdown
     @Slot()
     def shutdown(self):
+        # unload the shared library before destroying the cast object
+        ctypes.CDLL('libc.so.6').dlclose(libcast_handle)
         self.cast.destroy()
         QtWidgets.QApplication.quit()
 

--- a/desktop/src/python/pysidecaster.py
+++ b/desktop/src/python/pysidecaster.py
@@ -4,7 +4,7 @@ import os.path
 import sys
 import ctypes
 
-libcast = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL) # load the libcast.so shared library
+libcast_handle = ctypes.CDLL('./libcast.so', ctypes.RTLD_GLOBAL)._handle # load the libcast.so shared library
 pyclariuscast = ctypes.cdll.LoadLibrary('./pyclariuscast.so') # load the pyclariuscast.so shared library
 
 import pyclariuscast
@@ -195,6 +195,8 @@ class MainWidget(QtWidgets.QMainWindow):
     # handles shutdown
     @Slot()
     def shutdown(self):
+        # unload the shared library before destroying the cast object
+        ctypes.CDLL('libc.so.6').dlclose(libcast_handle)
         self.cast.destroy()
         QtWidgets.QApplication.quit()
 


### PR DESCRIPTION
…cast.destroy() call.