### PR TITLE
Fix compile error in Visual Studio

### DIFF
--- a/desktop/src/include/cast/cast_def.h
+++ b/desktop/src/include/cast/cast_def.h
@@ -182,7 +182,11 @@ typedef struct _CusLineF
 } CusLineF;
 
 #ifndef CAST_DEPRECATED
-#define CAST_DEPRECATED __attribute__ ((__deprecated__))
+#  ifdef _MSC_VER
+#    define CAST_DEPRECATED __declspec(deprecated)
+#  else
+#    define CAST_DEPRECATED __attribute__ ((__deprecated__))
+#  endif
 #endif
 
 CAST_DEPRECATED typedef struct _CusLineF CusLine;

--- a/desktop/src/include/cast/cast_export.h
+++ b/desktop/src/include/cast/cast_export.h
@@ -29,7 +29,11 @@
 #endif
 
 #ifndef CAST_DEPRECATED
-#  define CAST_DEPRECATED __attribute__ ((__deprecated__))
+#  ifdef _MSC_VER
+#    define CAST_DEPRECATED __declspec(deprecated)
+#  else
+#    define CAST_DEPRECATED __attribute__ ((__deprecated__))
+#  endif
 #endif
 
 #ifndef CAST_DEPRECATED_EXPORT


### PR DESCRIPTION
CAST_DEPRECATED should be defined as '__declspec(deprecated)' in Visual Studio.