### PR TITLE
Add MSVC compatibility to cast_export.h

### DIFF
--- a/include/cast/cast_export.h
+++ b/include/cast/cast_export.h
@@ -2,6 +2,18 @@
 #ifndef CAST_EXPORT_H
 #define CAST_EXPORT_H
 
+#ifdef _MSC_VER
+#  define CAST_HELPER_DLL_IMPORT __declspec(dllimport)
+#  define CAST_HELPER_DLL_EXPORT __declspec(dllexport)
+#  define CAST_HELPER_DLL_LOCAL
+#  define CAST_DEPRECATED __declspec(deprecated)
+#else
+#  define CAST_HELPER_DLL_IMPORT __attribute__((visibility("default")))
+#  define CAST_HELPER_DLL_EXPORT __attribute__((visibility("default")))
+#  define CAST_HELPER_DLL_LOCAL  __attribute__((visibility("hidden")))
+#  define CAST_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+
 #ifdef CAST_STATIC_DEFINE
 #  define CAST_EXPORT
 #  define CAST_NO_EXPORT
@@ -9,20 +21,16 @@
 #  ifndef CAST_EXPORT
 #    ifdef cast_EXPORTS
         /* We are building this library */
-#      define CAST_EXPORT __attribute__((visibility("default")))
+#      define CAST_EXPORT CAST_HELPER_DLL_EXPORT
 #    else
         /* We are using this library */
-#      define CAST_EXPORT __attribute__((visibility("default")))
+#      define CAST_EXPORT CAST_HELPER_DLL_IMPORT
 #    endif
 #  endif
 
 #  ifndef CAST_NO_EXPORT
-#    define CAST_NO_EXPORT __attribute__((visibility("hidden")))
+#    define CAST_NO_EXPORT CAST_HELPER_DLL_LOCAL
 #  endif
-#endif
-
-#ifndef CAST_DEPRECATED
-#  define CAST_DEPRECATED __attribute__ ((__deprecated__))
 #endif
 
 #ifndef CAST_DEPRECATED_EXPORT


### PR DESCRIPTION
Modified `cast_export.h` to support MSVC by conditionally replacing GCC-specific `__attribute__` usage with `__declspec`.

This issue appears to have been resolved in an earlier release (#124), but has since been reverted in version 10.