### PR TITLE
docs: getting-started, API & parameter references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ This repository contains all related items for the Clarius Cast API
 
 https://github.com/clariusdev/cast/releases
 
+# Documentation
+
+- [Getting Started](docs/getting-started.md) — connect, stream images, control imaging, and capture raw data
+- [API Reference](docs/api-reference.md) — every function, callback, enumeration, and struct
+- [Parameter Reference](docs/parameters.md) — user-function commands and low-level research parameters
+
+> Documentation tracks the publicly released **v12** API.
+
 # Overview
 
 The Cast API is based on the Clarius Cast protocol that the Clarius App uses for streaming images to multiple clients at once. Its primary use is for research purposes when access to real-time images is required, the Cast API provides a relatively simple way to get started. The pure C API is deployed on desktop only, primarily because Clarius uses Qt heavily, a library that can often introduce difficulties when deploying or linking on mobile platforms. For commercial users wanting to deploy on mobile, Clarius has created a Java version specifically for interfacing to the Clarius App in an Android environment and an Objective-C framework specifically for interfacing to the Clarius App in an iOS environment.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,185 @@
+# Cast API Reference
+
+Complete reference for the **v12** Cast C API. Declarations live in
+[`include/cast`](../include/cast):
+
+- [`cast.h`](../include/cast/cast.h) — functions and the init struct
+- [`cast_def.h`](../include/cast/cast_def.h) — enumerations and data structs
+- [`cast_cb.h`](../include/cast/cast_cb.h) — callback signatures
+
+All functions are `extern "C"`, exported with `CAST_EXPORT`, and return `0`
+(`CUS_SUCCESS`) / `-1` (`CUS_FAILURE`) unless noted. The Clarius App must be running and
+connected to a probe. For the call flow see [getting-started.md](getting-started.md); for
+control commands and research parameters see [parameters.md](parameters.md).
+
+## Conventions
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `CUS_SUCCESS` | `0` | success |
+| `CUS_FAILURE` | `-1` | failure |
+| `CUS_MAXTGC` | `10` | size of TGC arrays in image info structs |
+
+## Lifecycle & connection
+
+| Function | Description |
+|----------|-------------|
+| `int castInit(const CusInitParams* params)` | Initialize the module. Must be called first. |
+| `CusInitParams castDefaultInitParams(void)` | Zero-initialized init params. |
+| `int castDestroy(void)` | Free resources; call before exit. |
+| `int castConnect(const char* ipAddress, unsigned int port, const char* cert, CusConnectFn fn)` | Connect to a probe. Pass `"research"` as `cert` to bypass authentication. |
+| `int castDisconnect(CusReturnFn fn)` | Disconnect. |
+| `int castIsConnected(void)` | `1` connected, `0` not, `-1` not initialized. |
+| `int castFwVersion(CusPlatform platform, char* version, int sz)` | Firmware version for a platform (buffer ≥ 64 bytes). |
+| `int castProbeInfo(CusProbeInfo* info)` | Probe hardware info. |
+
+### `CusInitParams`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `args.argc`, `args.argv` | `int`, `char**` | Forwarded to the library (Qt graphics buffer init). |
+| `storeDir` | `const char*` | Writable directory for security keys. |
+| `newProcessedImageFn` | `CusNewProcessedImageFn` | Scan-converted frames. |
+| `newRawImageFn` | `CusNewRawImageFn` | Pre-scan-converted / RF frames. |
+| `newSpectralImageFn` | `CusNewSpectralImageFn` | M / PW spectral blocks. |
+| `newImuDataFn` | `CusNewImuDataFn` | IMU samples. |
+| `freezeFn` | `CusFreezeFn` | Freeze/run state. |
+| `buttonFn` | `CusButtonFn` | Physical button presses. |
+| `progressFn` | `CusProgressFn` | Readback (download) progress. |
+| `errorFn` | `CusErrorFn` | Error messages. |
+| `width`, `height` | `int` | Output buffer dimensions in pixels. |
+
+## Image output
+
+| Function | Description |
+|----------|-------------|
+| `int castSetOutputSize(int w, int h)` | Set scan-conversion output dimensions (1:1 pixel aspect; black borders fill the rest). |
+| `int castSeparateOverlays(int en)` | Deliver grayscale and color/strain overlay as separate callbacks. |
+| `int castSetFormat(CusImageFormat format)` | Output format for processed images (default ARGB). |
+
+## Imaging control
+
+| Function | Description |
+|----------|-------------|
+| `int castUserFunction(CusUserFunction cmd, double val, CusReturnFn fn)` | Run a control command. `SetDepth` uses `val` (cm), `SetGain` uses `val` (%); most others ignore `val`. |
+
+See the full [`CusUserFunction` list](parameters.md#user-functions).
+
+## Research (low-level) control
+
+> ⚠️ These reach below the standard controls and can drive the transducer outside the
+> validated safety envelope. See [parameters.md](parameters.md#research-parameters).
+
+| Function | Description |
+|----------|-------------|
+| `int castSetParameter(const char* prm, double val, CusReturnFn fn)` | Set a low-level numeric parameter. |
+| `int castEnableParameter(const char* prm, int en, CusReturnFn fn)` | Enable/disable a low-level boolean parameter. |
+| `int castSetPulse(const char* prm, const char* shape, CusReturnFn fn)` | Set a transmit pulse shape string. |
+
+## Raw data
+
+The probe must be **frozen** with raw-data buffering enabled in the App. See
+[getting started, step 6](getting-started.md#6-capture-raw-data).
+
+| Function | Description |
+|----------|-------------|
+| `int castRawDataAvailability(CusRawAvailabilityFn fn)` | Report buffered B and IQ/RF frame timestamps. |
+| `int castRequestRawData(long long start, long long end, int lzo, CusRawRequestFn fn)` | Request frames by ns timestamp (`0,0` = all). `lzo=1` → compressed tarball. Callback returns byte size to allocate. |
+| `int castReadRawData(void** data, CusRawFn fn)` | Download requested data into a pre-allocated buffer. |
+
+## Capture authoring (v12)
+
+Compose a capture and submit it to the current exam. See
+[getting started, step 7](getting-started.md#7-author-captures-v12).
+
+| Function | Description |
+|----------|-------------|
+| `int castStartCapture(long long timestamp)` | Begin a capture for the frame at `timestamp`; returns a capture `id` (or `-1`). |
+| `int castAddImageOverlay(int id, const void* data, int width, int height, float r, float g, float b, float a)` | Add an 8-bit grayscale overlay colorized by RGBA (each 0.0–1.0). `width`/`height` must match `castInit`. |
+| `int castAddLabelOverlay(int id, const char* text, double x, double y, double width, double height)` | Add a text label (pixel coordinates). |
+| `int castAddMeasurement(int id, CusMeasurementType type, const char* label, const double* pts, int count)` | Add a distance/trace/area measurement. `count` is the number of *doubles* in `pts`, not points. |
+| `int castFinishCapture(int id, CusReturnFn fn)` | Finalize and submit the capture. |
+
+## Callbacks
+
+Signatures from [`cast_cb.h`](../include/cast/cast_cb.h):
+
+| Callback | Signature | Fires when |
+|----------|-----------|------------|
+| `CusConnectFn` | `(int imagePort, int imuPort, int swRevMatch)` | Connection result; ports are UDP stream ports, `swRevMatch` flags API/App version match. |
+| `CusReturnFn` | `(int retCode)` | Generic success/failure for an async call. |
+| `CusNewRawImageFn` | `(const void* img, const CusRawImageInfo* nfo, int npos, const CusPosInfo* pos)` | Pre-scan / RF frame ready. |
+| `CusNewProcessedImageFn` | `(const void* img, const CusProcessedImageInfo* nfo, int npos, const CusPosInfo* pos)` | Scan-converted frame ready. |
+| `CusNewSpectralImageFn` | `(const void* img, const CusSpectralImageInfo* nfo)` | M/PW spectral block ready. |
+| `CusFreezeFn` | `(int state)` | `1` frozen, `0` imaging. |
+| `CusButtonFn` | `(CusButton btn, int clicks)` | Physical button pressed. |
+| `CusProgressFn` | `(int progress)` | Download progress (percent). |
+| `CusRawAvailabilityFn` | `(int res, int n_b, const long long* b, int n_iqrf, const long long* iqrf)` | Buffered raw-data timestamps. |
+| `CusRawRequestFn` | `(int res, const char* extension)` | Raw request sized; `extension` is the package type. |
+| `CusRawFn` | `(int res)` | Raw download complete (`res` = bytes). |
+| `CusErrorFn` | `(const char* msg)` | An error occurred. |
+| `CusNewImuDataFn` | `(const CusPosInfo* pos)` | Streamed IMU sample. |
+
+> Callbacks run on the SDK's threads — keep them short and hand data to your own queues.
+
+## Enumerations
+
+From [`cast_def.h`](../include/cast/cast_def.h).
+
+**`CusPlatform`** — `V1` (first generation), `HD`, `HD3`
+
+**`CusImageFormat`** — `Uncompressed` (32-bit ARGB), `Uncompressed8Bit` (8-bit gray),
+`Jpeg`, `Png`
+
+**`CusButton`** — `ButtonUp`, `ButtonDown`, `ButtonHandle`
+
+**`CusMeasurementType`** — `CusMeasurementTypeDistance` (1), `CusMeasurementTypeTraceDistance`,
+`CusMeasurementTypeTraceArea`
+
+**`CusUserFunction`** — the control commands for `castUserFunction`; see the
+[full table](parameters.md#user-functions).
+
+## Data structures
+
+From [`cast_def.h`](../include/cast/cast_def.h). These mirror the Solum structs.
+
+### `CusProcessedImageInfo` (scan-converted frames)
+
+`width`, `height`, `bitsPerPixel`, `imageSize` (bytes), `micronsPerPixel` (1:1),
+`originX`/`originY` (microns), `tm` (ns), `angle`, `fps`, `overlay` (1 = color/strain
+overlay), `format` (`CusImageFormat`), `tgc[CUS_MAXTGC]`.
+
+### `CusRawImageInfo` (pre-scan / RF frames)
+
+`lines`, `samples`, `bitsPerSample`, `axialSize`/`lateralSize` (microns), `tm` (ns),
+`jpeg` (byte size, `0` if uncompressed), `rf` (1 = RF, 0 = envelope), `angle`, `fps`,
+`tgc[CUS_MAXTGC]`.
+
+### `CusSpectralImageInfo` (M / PW)
+
+`lines`, `samples`, `bitsPerSample`, `period` (s), `micronsPerSample` (M),
+`velocityPerSample` (m/s, PW), `pw` (1 = PW, 0 = M).
+
+### `CusPosInfo` (IMU / positional)
+
+`tm` (ns), gyro `gx/gy/gz` (rad/s), accel `ax/ay/az` (normalized to g), magnetometer
+`mx/my/mz` (normalized to Earth's field), orientation quaternion `qw/qx/qy/qz`.
+
+### `CusProbeInfo`
+
+`version` (1 = gen 1, 2 = HD, 3 = HD3), `elements`, `pitch`, `radius` (mm),
+`frequency` (Hz).
+
+### `CusTgcInfo`, `CusPointF`, `CusLineF`
+
+`CusTgcInfo`: `depth` (mm), `gain` (dB). `CusPointF`: `x`, `y`. `CusLineF`: `p1`, `p2`.
+
+## Deprecated aliases
+
+`CusLine` → `CusLineF`, `CusPoint` → `CusPointF`.
+
+## v13 preview (not yet released)
+
+The next API adds a `newImageReadyFn` callback (pull model), `CusRawCompression`
+replacing the integer `lzo` flag on `castRequestRawData`, and a `castSetEnum()` function;
+the capture-authoring functions are being reworked. Build against v12 until v13 ships.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,190 @@
+# Getting Started with the Cast API
+
+This guide walks through writing a Cast application: connecting to a probe, receiving
+real-time images, controlling basic imaging, and pulling raw data. It targets the
+publicly released **v12** API. Snippets are C using the headers in
+[`include/cast`](../include/cast); the same sequence applies to the Python
+(`pyclariuscast`), Swift, and Android bindings in [`examples`](../examples).
+
+> 🔴 **The Clarius App must be running and connected to a probe to use the Cast API.**
+> Cast is a *secondary* connection for streaming — it cannot run stand-alone. The PC or
+> device running your Cast program must be on the **same wireless network** as the probe
+> and the App. Contrast this with [Solum](https://github.com/clariusdev/solum), which
+> connects to the probe directly without the App.
+
+## The big picture
+
+```mermaid
+flowchart LR
+  prb[Probe]
+  subgraph mobile[Mobile Device]
+    app[Clarius App]
+  end
+  subgraph pc[PC / device]
+    cast[Your Cast app]
+  end
+  prb <-- Primary Connection --> app
+  prb <-- Cast Connection --> cast
+```
+
+Lifecycle:
+
+```
+castInit(callbacks, width, height)
+castConnect(ip, port, cert, fn)
+  -> imageCallback(image) fires repeatedly
+  -> castUserFunction(...) to freeze / change params
+castDisconnect()
+castDestroy()
+```
+
+## 1. Find the network information
+
+For a Cast-licensed probe, the Clarius App shows the probe's IP address and Cast port
+when you tap the battery/temperature display area. Both are **required** to connect.
+
+- The address is typically on the probe's own Wi-Fi network (SSID prefixed `DIRECT-`).
+  The network password is on the App's **Status** page.
+- Optionally set **Clarius Cast Permission → Research** in the App to force the Cast port
+  to **5828**, which makes automated connections simpler.
+
+## 2. Initialize
+
+Start from `castDefaultInitParams()`, register callbacks, set the output buffer size, and
+call `castInit()`. It must succeed before anything else.
+
+```c
+#include <cast/cast.h>
+
+CusInitParams p = castDefaultInitParams();
+p.args.argc = argc;
+p.args.argv = argv;
+p.storeDir  = "/path/to/keys";  // writable dir for security keys
+p.width     = 640;
+p.height    = 480;
+
+p.newProcessedImageFn = newProcessedImageFn; // scan-converted frames
+p.newRawImageFn       = newRawImageFn;        // pre-scan / RF frames
+p.newSpectralImageFn  = newSpectralImageFn;   // M / PW spectra
+p.newImuDataFn        = newImuDataFn;          // IMU samples
+p.freezeFn            = freezeFn;
+p.buttonFn            = buttonFn;
+p.progressFn          = progressFn;
+p.errorFn             = errorFn;
+
+if (castInit(&p) < 0)
+    return -1;
+```
+
+All callbacks are listed in the [API reference](api-reference.md#callbacks). Functions
+return `0` (`CUS_SUCCESS`) / `-1` (`CUS_FAILURE`) unless noted.
+
+## 3. Connect
+
+```c
+// pass "research" as the certificate to bypass authentication
+castConnect("192.168.1.1", 5828, "research", connectFn);
+```
+
+```c
+void connectFn(int imagePort, int imuPort, int swRevMatch)
+{
+    if (imagePort == CUS_FAILURE) { /* connection failed */ return; }
+    if (swRevMatch == CUS_FAILURE) {
+        // API and App versions mismatch — update the Cast API to match the App
+    }
+    // imagePort / imuPort are the UDP ports now streaming
+}
+```
+
+> **Version lock.** The Cast API performs a firmware check on connect and has **no**
+> forward/backward compatibility. When Clarius releases a new App, download the matching
+> Cast binaries from [releases](https://github.com/clariusdev/cast/releases). A
+> `swRevMatch` of `CUS_FAILURE` means your API build doesn't match the running App.
+
+## 4. Receive images
+
+```c
+void newProcessedImageFn(const void* img, const CusProcessedImageInfo* nfo,
+                         int npos, const CusPosInfo* pos)
+{
+    // img is nfo->imageSize bytes; default format is 32-bit ARGB.
+    // nfo->width x nfo->height; pos[0..npos) carries IMU samples for this frame.
+}
+```
+
+- Default output is uncompressed 32-bit ARGB; switch with `castSetFormat()` (8-bit gray,
+  JPEG, PNG).
+- Resize output any time with `castSetOutputSize(w, h)`.
+- Call `castSeparateOverlays(1)` to receive grayscale and color/strain overlays as
+  separate callbacks.
+- Pre-scan-converted (polar) and RF frames arrive on `newRawImageFn`; check `nfo->rf`.
+- M-mode and PW spectra arrive on `newSpectralImageFn`.
+
+IMU data streams when enabled in the App; it arrives both tagged on image frames (`pos`)
+and via `newImuDataFn`.
+
+## 5. Control imaging
+
+Cast offers *secondary* control — handy, but the App remains the primary UI. Use
+`castUserFunction()` with a `CusUserFunction` command:
+
+```c
+castUserFunction(Freeze, 0, returnFn);     // toggle freeze
+castUserFunction(SetDepth, 7.0, returnFn); // depth in cm
+castUserFunction(SetGain, 60.0, returnFn); // gain in %
+castUserFunction(ColorDoppler, 0, returnFn); // switch mode
+```
+
+Most commands ignore the `val` argument; `SetDepth` and `SetGain` use it. See the full
+[command list](parameters.md#user-functions). For lower-level acoustic control there is a
+separate set of [research parameters](parameters.md#research-parameters).
+
+## 6. Capture raw data
+
+Raw data (IQ, RF, envelope) is read off the probe once imaging is **frozen** and raw-data
+buffering was enabled in the App (the **Buffer** mode icon). The exception is RF
+streaming, which interleaves in real time when RF mode is on.
+
+```c
+// after freezing (castUserFunction(Freeze, ...))
+castRawDataAvailability(availFn);             // 1. list buffered timestamps
+castRequestRawData(0, 0, 1, reqFn);           // 2. request all (lzo=1 compresses)
+// reqFn returns the byte size to allocate, then:
+castReadRawData(&buffer, rawFn);              // 3. download into your buffer
+```
+
+`castRequestRawData(start, end, lzo, fn)` selects frames by nanosecond timestamp
+(`0,0` = all buffered); `lzo=1` returns an LZO-compressed tarball. The package format is
+documented in the [research repository](https://github.com/clariusdev/research).
+
+## 7. Author captures (v12)
+
+The v12 API can compose a capture (image + overlays + labels + measurements) and submit
+it back to the exam:
+
+```c
+int id = castStartCapture(timestamp);
+castAddImageOverlay(id, data, w, h, 1.0f, 0.0f, 0.0f, 0.5f); // red @ 50% opacity
+castAddLabelOverlay(id, "ROI", x, y, w, h);
+double pts[4] = { x1, y1, x2, y2 };
+castAddMeasurement(id, CusMeasurementTypeDistance, "len", pts, 4);
+castFinishCapture(id, returnFn);
+```
+
+> These capture-authoring functions exist in v12. They are being reworked in v13 — build
+> against v12 if you depend on them today.
+
+## 8. Disconnect and clean up
+
+```c
+castDisconnect(returnFn);
+castDestroy();   // free resources before exiting
+```
+
+## Where to go next
+
+- [API reference](api-reference.md) — every function, callback, enum, and struct
+- [Parameter reference](parameters.md) — user functions and low-level research parameters
+- [Raw data formats](https://github.com/clariusdev/research) — decoding captured IQ/RF/envelope
+- Example programs in [`examples`](../examples) (`caster`, `caster_qt`, `python`, Swift, Android)

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,0 +1,158 @@
+# Cast Parameter & Command Reference
+
+Two ways to control the probe through Cast: high-level **user functions** (the same
+actions a button or the App UI triggers) and low-level **research parameters** (direct
+acoustic/sequencing control). For function signatures see the
+[API reference](api-reference.md); for the call flow see [getting-started.md](getting-started.md).
+
+## User functions
+
+Invoke with `castUserFunction(cmd, val, fn)`. Only `SetDepth` and `SetGain` use `val`;
+all other commands ignore it.
+
+### Imaging & display
+
+| Command | Action |
+|---------|--------|
+| `Freeze` | Toggle freeze. |
+| `CaptureImage` | Capture a still image. |
+| `CaptureCine` | Capture a cine. |
+| `DepthDec` / `DepthInc` | Decrease / increase depth. |
+| `SetDepth` | Set depth (uses `val`, cm). |
+| `GainDec` / `GainInc` | Decrease / increase gain. |
+| `SetGain` | Set gain (uses `val`, %). |
+| `AutoGain` | Toggle auto gain. |
+| `ContrastDec` / `ContrastInc` | Decrease / increase contrast. |
+| `Zoom` | Toggle zoom. |
+| `Flip` | Toggle horizontal flip. |
+| `CenterGuide` | Toggle center guide. |
+| `FullScreen` | Toggle full screen. |
+| `VoiceCommand` | Toggle voice controls. |
+
+### Modes
+
+| Command | Action |
+|---------|--------|
+| `BMode` | B-mode. |
+| `TMode` | T-mode. |
+| `MMode` | M-mode. |
+| `ColorDoppler` | Color Doppler. |
+| `PowerDoppler` | Power Doppler. |
+| `PwDoppler` | Pulsed-wave Doppler (when available). |
+| `NeedleEnhance` | Needle enhance (when available). |
+| `NeedleSide` | Toggle needle-enhance side. |
+| `Strain` | Strain elastography (when available). |
+| `Ceus` | Contrast-enhanced mode (when available). |
+| `RfMode` | RF mode (when available). |
+
+### Color Doppler controls
+
+| Command | Action |
+|---------|--------|
+| `ColorGainDec` / `ColorGainInc` | Decrease / increase color gain. |
+| `ColorPrfDec` / `ColorPrfInc` | Decrease / increase color PRF. |
+
+### Cine & layout
+
+| Command | Action |
+|---------|--------|
+| `PlayCine` | Play cine (when frozen). |
+| `PreviousFrame` / `NextFrame` | Step cine frames. |
+| `SwitchArray` | Switch array (multi-array probes). |
+| `Split1` / `Split2` / `Split4` | Split screen into 1 / 2 / 4 displays. |
+| `SplitNext` | Activate the next display. |
+| `Annotate` | Open annotations. |
+| `ClearScreen` | Clear the screen. |
+
+## Research parameters
+
+> ⚠️ **Safety.** Research parameters bypass the optimized presets and can change the
+> acoustic output of the transducer, pushing imaging **outside the safety limits Clarius
+> validates**, degrading image quality, or destabilizing the system. They require an
+> appropriate license and are intended for research. Parameters marked **\*\*** directly
+> affect acoustic output.
+
+Access them through three calls:
+
+```c
+castSetParameter("txFreq", 5.0, returnFn);     // numeric value
+castEnableParameter("sa", 1, returnFn);        // boolean enable/disable
+castSetPulse("txPulseGen", "+-", returnFn);    // transmit pulse shape string
+```
+
+The Solum SDK exposes the **same** parameter set via
+`solumSetLowLevelParam`/`solumEnableLowLevelParam`/`solumSetLowLevelPulse`. The
+authoritative, mode-by-mode list with value semantics lives in the
+[research repository](https://github.com/clariusdev/research).
+
+### Numeric parameters
+
+**Generic**
+
+| Parameter | Meaning |
+|-----------|---------|
+| `maxFrameRate` | Frame-rate limit in Hz (0–100, `0` = no limit). |
+
+**Greyscale**
+
+| Parameter | Meaning |
+|-----------|---------|
+| `txFreq` ** | Transmit frequency (MHz). |
+| `txFreqInv` ** | Transmit frequency for the inversion pulse (MHz). |
+| `txFn` ** | Transmit f-number. |
+| `txApt` ** | Max transmit aperture in elements (2–64). |
+| `txFocus` ** | Focus depth (cm). |
+| `vpp` ** | Positive amplitude (V, 10–37). |
+| `vnn` ** | Negative amplitude (V, 10–37). |
+| `ceVpp` ** | Positive amplitude for CEUS (V, 10–37). |
+| `ceVnn` ** | Negative amplitude for CEUS (V, 10–37). |
+| `steer` ** | Image steering (degrees). |
+| `rxFn` | Receive f-number. |
+| `rxFreqShallow` | Start demodulation frequency (MHz). |
+| `rxFreqDeep` | End demodulation frequency (MHz). |
+| `speedOfSound` | Speed-of-sound correction (m/s). |
+| `rfDecimation` | Decimation factor for IQ data. |
+| `envDecimation` | Decimation factor for envelope/grayscale data. |
+| `rfDecim` | Decimation factor of RF acquisition. |
+| `dyn` | Dynamic range (dB). |
+| `nf` | Noise floor (dB). |
+
+**Color / Power Doppler**
+
+| Parameter | Meaning |
+|-----------|---------|
+| `cfiPrf` ** | PRF (kHz; range varies per probe/preset). |
+| `cfiTxFreq` ** | Transmit frequency (MHz). |
+| `color steer` | Steering angle (degrees). |
+| `cfiEnsemble` ** | Ensemble / transmits per line (6–16). |
+
+**Pulsed-Wave Doppler**
+
+| Parameter | Meaning |
+|-----------|---------|
+| `pwPrf` ** | PRF (kHz; range varies per probe/preset). |
+| `pwTxFreq` ** | Transmit frequency (MHz). |
+| `pw gate size` | Gate size (mm). |
+| `pw steer` | Steering angle (degrees). |
+| `pw angle correct` | Correction angle (degrees). |
+
+### Boolean parameters (greyscale)
+
+| Parameter | Meaning |
+|-----------|---------|
+| `sa` | Synthetic aperture. |
+| `pih` | Pulse-inversion harmonics. |
+| `trapezoidal` | Extended FOV for linear probes. |
+
+### Pulse-shape (string) parameters
+
+| Parameter | Meaning |
+|-----------|---------|
+| `txPulseGen` ** | Transmit pulse. |
+| `txPulsePen` ** | Transmit pulse in penetration mode. |
+| `txPulseInv` ** | Transmit pulse for the inversion pulse. |
+| `cfiPulse` ** | Color/power transmit pulse. |
+| `pwPulse` ** | PW transmit pulse. |
+
+** Changing this parameter may alter the acoustic output of the transducer, making
+imaging operate outside the safety parameters Clarius has programmed into the device.


### PR DESCRIPTION
Adds a `docs/` folder and relinks the README:
- getting-started.md — connect, stream images, control, capture raw data
- api-reference.md — functions, callbacks, enums, structs
- parameters.md — user-function commands and low-level research parameters

Tracks the published v12 API; v13 changes noted as preview only.